### PR TITLE
Get gtdb mash fix

### DIFF
--- a/Mods/config_DBs.txt
+++ b/Mods/config_DBs.txt
@@ -23,12 +23,12 @@ checkm2DB	[DBDir]/checkm2/CheckM2_database/uniref100.KO.1.dmnd
 
 #DBs for official GTDBtk scripts
 #GTDBtk_DB	[DBDir]/GTDBtk_ref/
-GTDBtk_DB	/ei/projects/8/88e80936-2a5d-4f4a-afab-6f74b374c765/data/cloudpool/DB/MarkerG/GTDB_r226_MGTK/gtdb	#Updated by get_gtdb.py
-GTDBtk_mash	/ei/projects/8/88e80936-2a5d-4f4a-afab-6f74b374c765/data/cloudpool/DB/MarkerG/GTDB_r226_MGTK/gtdb/mashD	#Updated by get_gtdb.py
+GTDBtk_DB	[DBDir]/MarkerG/GTDB_r226_MGTK/gtdb/release226/	#Updated by get_gtdb.py
+#GTDBtk_mash	[DBDir]/MarkerG/GTDB_r226_MGTK/gtdb/release226/mashD	#Updated by get_gtdb.py
 #this is used for GTDB python script from Joachim and MAG->GTDB marker gene tasks.. independent of GTDBtk version
-GTDBPath	/ei/projects/8/88e80936-2a5d-4f4a-afab-6f74b374c765/data/cloudpool/DB/MarkerG/GTDB_r226_MGTK/markerGenes	#Updated by get_gtdb.py
-GTDB_GTDB	/ei/projects/8/88e80936-2a5d-4f4a-afab-6f74b374c765/data/cloudpool/DB/MarkerG/GTDB_r226_MGTK/gtdb_r226_lineageGTDB.tab	#Updated by get_gtdb.py
-GTDB_lnks	/ei/projects/8/88e80936-2a5d-4f4a-afab-6f74b374c765/data/cloudpool/DB/MarkerG/GTDB_r226_MGTK/gtdb_r226_clustering.tab	#Updated by get_gtdb.py
+GTDBPath	[DBDir]/MarkerG/GTDB_r226_MGTK/markerGenes	#Updated by get_gtdb.py
+GTDB_GTDB	[DBDir]/MarkerG/GTDB_r226_MGTK/gtdb_r226_lineageGTDB.tab	#Updated by get_gtdb.py
+GTDB_lnks	[DBDir]/MarkerG/GTDB_r226_MGTK/gtdb_r226_clustering.tab	#Updated by get_gtdb.py
 #GTDB_cutoff	[DBDir]/MarkerG/GTDB_r207v2_MF/markerGenes/cutoffs.txt
 GTDB_cutoff	[MFLRDir]/data/GTDBcutoffs.txt
 

--- a/helpers/install/GTDBTK.yml
+++ b/helpers/install/GTDBTK.yml
@@ -7,7 +7,7 @@ dependencies:
   - conda-forge::numpy
   - conda-forge::scipy
   - blas[build=openblas]
-  - gtdbtk=2.3
+  - gtdbtk=2.5
   - pigz=2.8
 #  - whokaryote=1.1.2 (downgrades pytorch etc..)
 #  - checkm2 >= 1 (downgrades pytorch etc..)

--- a/secScripts/GC/MG_LCA.pl
+++ b/secScripts/GC/MG_LCA.pl
@@ -60,17 +60,14 @@ if ($useGTDBmg eq "GTDB"){
 	$speciesLink = "GTDB_lnks"; $speciesCutoff = "GTDB_cutoff"; $subsetFile = "GTDBmg.subset.cats";
 	$speciesGTDB = "GTDB_GTDB"; $speciesDir = "GTDBPath"; $MGtag = "GTDBmg";
 }
-my $inSImap = getProgPaths($speciesLink);
-my $GTDBspecI = getProgPaths($speciesGTDB);
-my $SpecID=getProgPaths($speciesDir);#directoy with all 40 SpecI marker genes
-my %FMGcutoffs = %{readTabbed3(getProgPaths($speciesCutoff,0),1)};
-
 #make the distinction here, as not all Marker genes might be present in a certain experiment (e.g. no Archaea)
 my %FMGkeys = %{readTabbed3("$GCd/$subsetFile",1)};
 
 
-
-
+my $inSImap = getProgPaths($speciesLink);
+my $GTDBspecI = getProgPaths($speciesGTDB);
+my $SpecID=getProgPaths($speciesDir);#directoy with all 40 SpecI marker genes
+my %FMGcutoffs = %{readTabbed3(getProgPaths($speciesCutoff,0),1)};
 
 my $taxPerGene = "$SpecID/$MGtag.tax";
 reformatGTDBtax($taxPerGene, $inSImap,$GTDBspecI);

--- a/secScripts/MGS.pl
+++ b/secScripts/MGS.pl
@@ -481,7 +481,7 @@ if (!-e $GTDBtaxF || !-e"$annoDir/gtdbtk.summary.tsv" || !-e $GTDBtaxSto){
 	$cmd .= "mv $outD/GTDBTK.tax $outD/gtdbtk.summary.tsv $annoDir\n\ntouch $GTDBtaxSto";
 	#changed mem from 370 to 100 with GTDB-TK 2.1.0
 	my $tmpSHDD = $QSBopt{tmpSpace};	$QSBopt{tmpSpace} = "150G"; 
-	my ($jobName2, $tmpCmd) = qsubSystem($logDir."/GTDB.Rhcl.sh",$cmd,$canCore,int(200/$canCore)."G","GTDB_MGS","","",1,[],\%QSBopt);
+	my ($jobName2, $tmpCmd) = qsubSystem($logDir."/GTDB.Rhcl.sh",$cmd,$canCore,int(240/$canCore)."G","GTDB_MGS","","",1,[],\%QSBopt);
 	$QSBopt{tmpSpace} =$tmpSHDD;
 	push(@jobs2wait,$jobName2);
 	

--- a/secScripts/MGS/taxPerMGS_gtdb.pl
+++ b/secScripts/MGS/taxPerMGS_gtdb.pl
@@ -12,7 +12,7 @@ use Mods::GenoMetaAss qw( systemW gzipopen);
 #my $py3activate = getProgPaths("py3activate"); #source conda.. 
 my $GTDBtkBin = getProgPaths("GTDBtk");
 my $GTDBtkDB = getProgPaths("GTDBtk_DB");
-my $GTDBtkMash = getProgPaths("GTDBtk_mash");
+my $GTDBtkMash = getProgPaths("GTDBtk_mash",0);
 
 #die "$GTDBtkDB\n$GTDBtkMash\n";
 my $refMGd = $ARGV[0];
@@ -33,10 +33,18 @@ my $cmd = "";
 #--scratch_dir $tmpD 
 #$cmd .= "export GTDBTK_DATA_PATH=$GTDBtkDB\n";
 if ($GTDBtkBin =~ m/ activate /){
-	$GTDBtkBin =~ s/activate (\S+)/activate $1\nexport GTDBTK_DATA_PATH=$GTDBtkDB\nMVERSION=`mash --version`\n/;
+	$GTDBtkBin =~ s/activate (\S+)/activate $1\nexport GTDBTK_DATA_PATH=$GTDBtkDB\n/;
 }
-$cmd .= "$GTDBtkBin classify_wf -x fna --mash_db $GTDBtkMash/\$MVERSION/ --cpus $ncore --pplacer_cpus $pplacer_cores  --genome_dir $refMGd --out_dir $oDir"; #--scratch_dir $tmpD/GTtmp/ --genes
+
+my $mashArg="" ;
+if ($GTDBtkMash ne ""){ #for newer GTDBtk versions not supported
+	$mashArg = "--mash_db $GTDBtkMash/\$MVERSION/";
+	$cmd .= "MVERSION=`mash --version`"
+}
+
+$cmd .= "$GTDBtkBin classify_wf -x fna $mashArg --cpus $ncore --pplacer_cpus $pplacer_cores  --genome_dir $refMGd --out_dir $oDir"; #--scratch_dir $tmpD/GTtmp/ --genes
 print "\n\n".$cmd."\n\n";
+#die;
 systemW $cmd;
 
 systemW "rm -f $Bdir/gtdbtk.summary.tsv";


### PR DESCRIPTION
This combines a few changes

- **Remove mash directory**: When configuring for a GTDB released using GTDB-Tk 2.5 or greater, will comment out the `GTDBtk_mash` line in `config_DBs.txt`.
- **Fix [DBDir] interpolation**: Correctly use `[DBDir]` in config strings, was previously not getting detecting due to a newline in the strings being compared.
- **Don't install GTDB-Tk**: Defaults to not installing GTDB-Tk, but added a flag `--install-tk` which will install a release appropriate version, to allow for simpler downgrading to an older GTDB release.